### PR TITLE
changed the location of profile.png reference in resume.tex

### DIFF
--- a/resume.tex
+++ b/resume.tex
@@ -36,7 +36,7 @@
 %	Comment any of the lines below if they are not required
 %-------------------------------------------------------------------------------
 % Available options: circle|rectangle,edge/noedge,left/right
-% \photo[rectangle,edge,right]{./examples/profile}
+% \photo[rectangle,edge,right]{./profile}
 \name{Nanda}{Dipan}
 % \position{Software Architect{\enskip\cdotp\enskip}Security Expert}
 \address{15, Grayson Heights, Eden Mount, Leeds, LS4 2UD, United Kingdom}


### PR DESCRIPTION
The default photo is referenced with an incorrect path in resume.tex.

Thanks for creating this template, I really like how it looks!