### PR TITLE
Publication sorting issue fix.

### DIFF
--- a/cv/publications.tex
+++ b/cv/publications.tex
@@ -12,10 +12,10 @@
  	\nocite{Khan2014Incentive}
  	\nocite{Selimi2015Cloud}
 
+ 	\newrefcontext[sorting=ydnt]
  	\printbibliography[
- 	heading=none, 
- 	sorting=ydnt
- 	]
+ 	heading=none
+	]
  \end{refsection}
 
  %-------------------------------------------------------------------------------
@@ -26,8 +26,8 @@
  \begin{refsection}
      \nocite{Khan2014Prototyping}
 
+ 	\newrefcontext[sorting=ydnt]
  	\printbibliography[
- 	heading=none, 
- 	sorting=ydnt
- 	]
+ 	heading=none
+]
  \end{refsection}


### PR DESCRIPTION
The `publication.tex` generates biblatex Warning as below, and the sorting doesn't take effect

```plain
Package biblatex Warning: 'sorting' option to '\printbibliography' is no longer
 supported.
(biblatex)                Please use 'sorting' option to '\newrefcontext'.
```

This problem is stemmed from **biblatex** as discussed in [this issue](https://github.com/plk/biblatex/issues/345).

This PR fixed this publication sorting issue.